### PR TITLE
Add a reverse shell service for remote SSH login

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -1,6 +1,10 @@
 ---
 pi_hostname: "radio"
-url_to_show: "https://radio.svsticky.nl"
+
+sadserver_hostname: "svsticky.nl"
+sadserver_tunnel_user: "radio-tunnel"
+
+url_to_show: "https://radio.{{ sadserver_hostname }}/"
 
 wifi_networks:
   - ssid: "Woestgaafsecure"

--- a/ansible/tasks/sshd.yml
+++ b/ansible/tasks/sshd.yml
@@ -22,3 +22,16 @@
     group: "root"
     mode: "0644"
   notify: "reload sshd"
+
+- name: "copy reverse shell service"
+  template:
+    src: "templates/etc/systemd/system/ssh-tunnel-sadserver.service.j2"
+    dest: "/etc/systemd/system/ssh-tunnel-sadserver.service"
+  notify: "systemctl daemon-reload"
+
+- name: "start and enable reverse shell service"
+  systemd:
+    name: "ssh-tunnel-sadserver.service"
+    daemon_reload: true
+    enabled: true
+    state: "started"

--- a/ansible/templates/etc/systemd/system/ssh-tunnel-sadserver.service
+++ b/ansible/templates/etc/systemd/system/ssh-tunnel-sadserver.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=SSH tunnel to sadserver to establish reverse shell access
+
+Wants=network-online.target
+After=network-online.target
+
+StartLimitBurst=120
+StartLimitInterval=4500
+
+[Service]
+Type=simple
+
+# We disable StrictHostKeyChecking, because this runs non-interactively so we
+# can't inspect a host key anyway. This just makes it accept the first host key
+# it encounters for the host name, and uses that for verification from then on.
+ExecStart=/usr/bin/ssh \
+  -N \
+  -R 2222:localhost:22 \
+  -o StrictHostKeyChecking=no \
+  {{ sadserver_tunnel_user }}@{{ sadserver_hostname }}
+
+User=pi
+Group=pi
+
+Restart=always
+RestartSec=30
+# The retry logic basically does this:
+# If the target server is down, retry twice a minute for ~1 hour. If it's still down then, give up.
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds a systemd service that connects to sadserver at startup, establishing a remote port forward. This allows us to SSH in to the Pi from outside Woestgaafsecure, by connecting to a specific port on sadserver (which acts as a jump host).

In practice: `ssh pi@svsticky.nl -p 2222` will connect you to the Pi.

To do:
- [ ] Add an SSH keypair, for authentication to sadserver (probably encrypted with Ansible Vault?)
- [ ] Finish and merge the needed changes on sadserver (creating and locking down the tunnel user)

Fixes #3.